### PR TITLE
Fix support with Android SDK 30

### DIFF
--- a/oboe/src/java_interface/definitions.rs
+++ b/oboe/src/java_interface/definitions.rs
@@ -90,6 +90,7 @@ pub enum AudioDeviceType {
     BuiltinEarpiece = 1,
     BuiltinMic = 15,
     BuiltinSpeaker = 2,
+    BuiltinSpeakerSafe = 24,
     Bus = 21,
     Dock = 13,
     Fm = 14,


### PR DESCRIPTION
Currently, there's no support for `BuiltinSpeakerSafe` that produces panic.

https://developer.android.com/reference/android/media/AudioDeviceInfo#TYPE_BUILTIN_SPEAKER_SAFE