### PR TITLE
Update to jni 0.17

### DIFF
--- a/oboe/Cargo.toml
+++ b/oboe/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.2"
 optional = true
 
 [dependencies.jni]
-version = "0.14"
+version = "0.17"
 optional = true
 
 [features]

--- a/oboe/src/java_interface/utils.rs
+++ b/oboe/src/java_interface/utils.rs
@@ -106,7 +106,7 @@ pub fn call_method_string_arg_ret_bool<'a, S: AsRef<str>>(
 
 pub fn call_method_string_arg_ret_string<'a: 'b, 'b, S: AsRef<str>>(
     env: &'b JNIEnv<'a>,
-    subject: JObject,
+    subject: JObject<'a>,
     name: &str,
     arg: S,
 ) -> JResult<JavaStr<'a, 'b>> {
@@ -124,7 +124,7 @@ pub fn call_method_string_arg_ret_string<'a: 'b, 'b, S: AsRef<str>>(
 
 pub fn call_method_string_arg_ret_object<'a>(
     env: &JNIEnv<'a>,
-    subject: JObject,
+    subject: JObject<'a>,
     method: &str,
     arg: &str,
 ) -> JResult<JObject<'a>> {
@@ -137,7 +137,7 @@ pub fn call_method_string_arg_ret_object<'a>(
     .l()
 }
 
-pub fn get_package_manager<'a>(env: &JNIEnv<'a>, subject: JObject) -> JResult<JObject<'a>> {
+pub fn get_package_manager<'a>(env: &JNIEnv<'a>, subject: JObject<'a>) -> JResult<JObject<'a>> {
     env.call_method(
         subject,
         "getPackageManager",
@@ -153,7 +153,7 @@ pub fn has_system_feature<'a>(env: &JNIEnv<'a>, subject: JObject, name: &str) ->
 
 pub fn get_system_service<'a>(
     env: &JNIEnv<'a>,
-    subject: JObject,
+    subject: JObject<'a>,
     name: &str,
 ) -> JResult<JObject<'a>> {
     call_method_string_arg_ret_object(env, subject, "getSystemService", name)
@@ -161,7 +161,7 @@ pub fn get_system_service<'a>(
 
 pub fn get_property<'a: 'b, 'b>(
     env: &'b JNIEnv<'a>,
-    subject: JObject,
+    subject: JObject<'a>,
     name: &str,
 ) -> JResult<JavaStr<'a, 'b>> {
     call_method_string_arg_ret_string(env, subject, "getProperty", name)
@@ -169,7 +169,7 @@ pub fn get_property<'a: 'b, 'b>(
 
 pub fn get_devices<'a: 'b, 'b>(
     env: &'b JNIEnv<'a>,
-    subject: JObject,
+    subject: JObject<'a>,
     flags: i32,
 ) -> JResult<JObject<'a>> {
     env.call_method(


### PR DESCRIPTION
This updates oboe to use jni version 0.17. This prevents jni being compiled twice when depending on the cpal crate, which depends on jni 0.17 and oboe 0.3.

I wasn't able to update it to the latest version 0.18 of jni due to the following error:

```
error[E0277]: `?` couldn't convert the error to `jni::errors::Error`
  --> oboe/src/java_interface/devices_info.rs:68:59
   |
68 |                 .ok_or_else(|| "Invalid device direction")?,
   |                                                           ^ the trait `From<&str>` is not implemented for `jni::errors::Error`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
   = help: the following implementations were found:
             <jni::errors::Error as From<TryLockError<T>>>
   = note: required by `std::convert::From::from`
```