### PR TITLE
Update jni

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.3"
 optional = true
 
 [dependencies.jni]
-version = "0.18"
+version = "0.19"
 optional = true
 
 [features]


### PR DESCRIPTION
Bevy's cargo deny check failed because cpal depends on jni directly and via this crate.

This meant that there were multiple jni versions in our tree.

Please note that I haven't tested this, and haven't managed to build locally, so I'm going to see what CI says first - hopefully it will go through without issue.