### PR TITLE
Include `AdpfWrapper.cpp` when building the library

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -212,6 +212,7 @@ impl Builder {
         let src_files = &[
             "aaudio/AAudioLoader.cpp",
             "aaudio/AudioStreamAAudio.cpp",
+            "common/AdpfWrapper.cpp",
             "common/AudioSourceCaller.cpp",
             "common/AudioStream.cpp",
             "common/AudioStreamBuilder.cpp",


### PR DESCRIPTION
This fixes:

> java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "_ZN11AdpfWrapper5closeEv"

If possible, it would be nice to include this in a patch release.